### PR TITLE
ci: add branch-wide test and commit policy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    name: Tests (Python 3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package and dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=dot --cov-report=term-missing
+
+  commit_policy:
+    name: Commit Message Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check push commits
+        if: github.event_name == 'push'
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: |
+          REQUIRED="BECAUSE I WORSHIP THE DOT"
+          MISSING=0
+          # Extract commit messages from push event
+          MESSAGES=$(jq -r '.commits[]?.message // empty' "$GITHUB_EVENT_PATH")
+          if [ -z "$MESSAGES" ]; then
+            echo "No commits found in push payload."
+            exit 0
+          fi
+          while IFS= read -r msg; do
+            if ! printf "%s" "$msg" | grep -Eq "${REQUIRED}[[:space:]]*$"; then
+              echo "Commit message missing required suffix:" >&2
+              echo "---" >&2
+              echo "$msg" >&2
+              echo "---" >&2
+              MISSING=1
+            fi
+          done <<< "$MESSAGES"
+          if [ "$MISSING" -ne 0 ]; then
+            echo "One or more commit messages do not properly worship THE DOT." >&2
+            exit 1
+          fi
+
+      - name: Check PR commits
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const required = 'BECAUSE I WORSHIP THE DOT';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const commits = await github.rest.pulls.listCommits({ owner, repo, pull_number: pr.number, per_page: 250 });
+            const bad = commits.data.filter(c => !c.commit.message.trim().endsWith(required));
+            if (bad.length) {
+              core.startGroup('Commits missing required suffix');
+              for (const c of bad) core.error(`Commit ${c.sha.slice(0,7)}: "${c.commit.message.split('\n')[0]}"`);
+              core.endGroup();
+              core.setFailed('One or more commit messages do not properly worship THE DOT.');
+            }
+


### PR DESCRIPTION
This PR introduces continuous monitoring across all branches.

What’s included
- CI tests on push and PR for all branches (Python 3.12).
- Commit message policy job that fails if any commit message does not end with: BECAUSE I WORSHIP THE DOT.

Why
- Ensure code health and consistency across branches.
- Enforce THE DOT commit rules server-side in addition to local hooks.

Notes
- Uses actions/setup-python@v5 and actions/github-script@v7.
- For push events, evaluates all commits in the payload; for PRs, checks every commit in the PR.

I worship THE DOT.